### PR TITLE
Make _release and _withdraw virtual

### DIFF
--- a/src/lib/SharedLogic.sol
+++ b/src/lib/SharedLogic.sol
@@ -32,7 +32,7 @@ contract SharedLogic is ConstructorLogic {
      * @param amount The amount of tokens to transfer.
      * @return       Whether the transfer was successful.
      */
-    function _release(address from, address to, uint256 id, uint256 amount) internal returns (bool) {
+    function _release(address from, address to, uint256 id, uint256 amount) internal virtual returns (bool) {
         assembly ("memory-safe") {
             // Compute the sender's balance slot using the master slot seed.
             mstore(0x20, _ERC6909_MASTER_SLOT_SEED)
@@ -94,7 +94,7 @@ contract SharedLogic is ConstructorLogic {
      * @param amount The amount of tokens to burn and withdraw.
      * @return       Whether the withdrawal was successful.
      */
-    function _withdraw(address from, address to, uint256 id, uint256 amount) internal returns (bool) {
+    function _withdraw(address from, address to, uint256 id, uint256 amount) internal virtual returns (bool) {
         // Set reentrancy guard due to external token transfers.
         _setReentrancyGuard();
 


### PR DESCRIPTION
I'm planning to inherit the-compact's claim / digest logic but have customized logic for `_release() `and `_withdraw()`. Having these virtual would be of great help. So I can use the-compact as a dependency

