### PR TITLE
feat(domainseparator):make internal function virtual

### DIFF
--- a/src/lib/ConstructorLogic.sol
+++ b/src/lib/ConstructorLogic.sol
@@ -106,7 +106,7 @@ contract ConstructorLogic is Tstorish {
      * updating it if the chain ID has changed since deployment.
      * @return The current domain separator.
      */
-    function _domainSeparator() internal view returns (bytes32) {
+    function _domainSeparator() internal view virtual returns (bytes32) {
         return _INITIAL_DOMAIN_SEPARATOR.toLatest(_INITIAL_CHAIN_ID);
     }
 


### PR DESCRIPTION
It would be great if we can make the _domainSeparator virtual.

The stuff im building that's based on TheCompact's Claim Processor requires me to override this function.