### PR TITLE
feat(pin sigcheck): pinning signature validation implementation

### DIFF
--- a/src/lib/IdLib.sol
+++ b/src/lib/IdLib.sol
@@ -6,9 +6,7 @@ import { Scope } from "../types/Scope.sol";
 import { Lock } from "../types/Lock.sol";
 import { MetadataLib } from "./MetadataLib.sol";
 import { EfficiencyLib } from "./EfficiencyLib.sol";
-import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 import { CompactCategory } from "../types/CompactCategory.sol";
-
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 
 /**
@@ -31,7 +29,6 @@ library IdLib {
     using EfficiencyLib for address;
     using EfficiencyLib for ResetPeriod;
     using EfficiencyLib for Scope;
-    using SignatureCheckerLib for address;
     using EfficientHashLib for bytes;
 
     error NoAllocatorRegistered(uint96 allocatorId);

--- a/src/lib/SignatureCheckerLib.sol
+++ b/src/lib/SignatureCheckerLib.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Signature verification helper that supports both ECDSA signatures from EOAs
+/// and ERC1271 signatures from smart contract wallets like Argent and Gnosis safe.
+/// pinned implementation version from Solady:e0ef35adb0ccd1032794731a995cb599bba7b537
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/SignatureCheckerLib.sol)
+/// @author Modified from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/SignatureChecker.sol)
+
+library SignatureCheckerLib {
+    /// @dev Returns whether `signature` is valid for `signer` and `hash`.
+    /// If `signer` is a smart contract, the signature is validated with ERC1271.
+    /// Otherwise, the signature is validated with `ECDSA.recover`.
+    function isValidSignatureNowCalldata(address signer, bytes32 hash, bytes calldata signature) internal view returns (bool isValid) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Clean the upper 96 bits of `signer` in case they are dirty.
+            for { signer := shr(96, shl(96, signer)) } signer { } {
+                let m := mload(0x40)
+                mstore(0x00, hash)
+                if eq(signature.length, 64) {
+                    let vs := calldataload(add(signature.offset, 0x20))
+                    mstore(0x20, add(shr(255, vs), 27)) // `v`.
+                    mstore(0x40, calldataload(signature.offset)) // `r`.
+                    mstore(0x60, shr(1, shl(1, vs))) // `s`.
+                    let t :=
+                        staticcall(
+                            gas(), // Amount of gas left for the transaction.
+                            1, // Address of `ecrecover`.
+                            0x00, // Start of input.
+                            0x80, // Size of input.
+                            0x01, // Start of output.
+                            0x20 // Size of output.
+                        )
+                    // `returndatasize()` will be `0x20` upon success, and `0x00` otherwise.
+                    if iszero(or(iszero(returndatasize()), xor(signer, mload(t)))) {
+                        isValid := 1
+                        mstore(0x60, 0) // Restore the zero slot.
+                        mstore(0x40, m) // Restore the free memory pointer.
+                        break
+                    }
+                }
+                if eq(signature.length, 65) {
+                    mstore(0x20, byte(0, calldataload(add(signature.offset, 0x40)))) // `v`.
+                    calldatacopy(0x40, signature.offset, 0x40) // `r`, `s`.
+                    let t :=
+                        staticcall(
+                            gas(), // Amount of gas left for the transaction.
+                            1, // Address of `ecrecover`.
+                            0x00, // Start of input.
+                            0x80, // Size of input.
+                            0x01, // Start of output.
+                            0x20 // Size of output.
+                        )
+                    // `returndatasize()` will be `0x20` upon success, and `0x00` otherwise.
+                    if iszero(or(iszero(returndatasize()), xor(signer, mload(t)))) {
+                        isValid := 1
+                        mstore(0x60, 0) // Restore the zero slot.
+                        mstore(0x40, m) // Restore the free memory pointer.
+                        break
+                    }
+                }
+                mstore(0x60, 0) // Restore the zero slot.
+                mstore(0x40, m) // Restore the free memory pointer.
+
+                let f := shl(224, 0x1626ba7e)
+                mstore(m, f) // `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`.
+                mstore(add(m, 0x04), hash)
+                let d := add(m, 0x24)
+                mstore(d, 0x40) // The offset of the `signature` in the calldata.
+                mstore(add(m, 0x44), signature.length)
+                // Copy the `signature` over.
+                calldatacopy(add(m, 0x64), signature.offset, signature.length)
+                // forgefmt: disable-next-item
+                isValid := and(
+                    // Whether the returndata is the magic value `0x1626ba7e` (left-aligned).
+                    eq(mload(d), f),
+                    // Whether the staticcall does not revert.
+                    // This must be placed at the end of the `and` clause,
+                    // as the arguments are evaluated from right to left.
+                    staticcall(
+                        gas(), // Remaining gas.
+                        signer, // The `signer` address.
+                        m, // Offset of calldata in memory.
+                        add(signature.length, 0x64), // Length of calldata in memory.
+                        d, // Offset of returndata.
+                        0x20 // Length of returndata to write.
+                    )
+                )
+                break
+            }
+        }
+    }
+}

--- a/src/lib/ValidityLib.sol
+++ b/src/lib/ValidityLib.sol
@@ -7,7 +7,7 @@ import { IdLib } from "./IdLib.sol";
 import { ConsumerLib } from "./ConsumerLib.sol";
 import { EfficiencyLib } from "./EfficiencyLib.sol";
 import { DomainLib } from "./DomainLib.sol";
-import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
+import { SignatureCheckerLib } from "./SignatureCheckerLib.sol";
 
 /**
  * @title ValidityLib


### PR DESCRIPTION
TheCompact’s ValidityLib is using Solady's SignatureCheckerLib. 
In the Solady version that TheCompact is using, `isValidSignatureNowCalldata()` checks the signature length to decide whether to perform `ecrecover` (then ERC1271 fallback) based on the signature length (over 65 bytes it uses ERC1271)..
However, In the current Solady version, `isValidSignatureNowCalldata()` will `EXTCODESIZE` check, if `EXTCODESIZE` is non-zero, it goes straight to ERC1271.
Note: with the currently pinned Solady version, there is no security risk! 

Considering EIP7702 is around the cordner, this opens up some attack vectors specifically for credible commitments, should the newer Solady version be used.

According to EIP7702 Spec:

> “The delegation designation uses the banned opcode 0xef from EIP-3541 to designate the code has a special purpose. This designator requires all code executing operations to follow the address pointer to get the account's executable code, and requires all other code reading operations to act only on the delegation designator (0xef0100 || address). The following reading instructions are impacted: EXTCODESIZE, EXTCODECOPY, EXTCODEHASH, and the following executing instructions are impacted: CALL, CALLCODE, STATICCALL, DELEGATECALL, as well as transactions with destination targeting the code with delegation designation.
> For example, EXTCODESIZE would return 23 (the size of 0xef0100 || address), EXTCODEHASH would return keccak256(0xef0100 || address), and CALL would load the code from address and execute it in the context of authority.”

Attack Scenario:
- User locks resources into TheCompact
- User uses EIP7702 to upgrade EOA to a modular smart account, with a validator module. For example an ERC7579 passkey validator module
- User Signs a Compact to allow a solver to take out the funds, with a signature that would be valid with the passkey validator module
- When solver wants to send the claim, the user frontruns the solver's claim, by deactivating the validator module, or changing EIP7702 account implementation.

Remediation: 

- Allocators / Solvers can only trust ecrecover-able signatures, if the account is an EOA (EIP-7702). 
- I recommend adding the bytecode of the `isValidSignatureNowCalldata()` to TheCompact repository, to prevent future dependency upgrades to introduce the attack scenario mentioned above



