### PR TITLE
more nits

### DIFF
--- a/docs/TheCompact-Overview.md
+++ b/docs/TheCompact-Overview.md
@@ -1061,7 +1061,7 @@ struct MultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
+    bytes32[] additionalChains; // The element hashes from additional chains.
     uint256 id; // The token ID of the ERC6909 token to allocate.
     uint256 allocatedAmount; // The original allocated amount of ERC6909 tokens.
     Component[] claimants; // The claim recipients and amounts; specified by the arbiter.
@@ -1079,8 +1079,8 @@ struct ExogenousMultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
-    uint256 chainIndex; // The index after which to insert the current allocation hash.
+    bytes32[] additionalChains; // The element hashes from additional chains.
+    uint256 chainIndex; // The index after which to insert the current element hash.
     uint256 notarizedChainId; // The chain id used to sign the multichain claim.
     uint256 id; // The token ID of the ERC6909 token to allocate.
     uint256 allocatedAmount; // The original allocated amount of ERC6909 tokens.
@@ -1099,7 +1099,7 @@ struct BatchMultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
+    bytes32[] additionalChains; // The element hashes from additional chains.
     BatchClaimComponent[] claims; // The claim token IDs, recipients and amounts.
 }
 ```
@@ -1115,8 +1115,8 @@ struct ExogenousBatchMultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
-    uint256 chainIndex; // The index after which to insert the current allocation hash.
+    bytes32[] additionalChains; // The element hashes from additional chains.
+    uint256 chainIndex; // The index after which to insert the current element hash.
     uint256 notarizedChainId; // The chain id used to sign the multichain claim.
     BatchClaimComponent[] claims; // The claim token IDs, recipients and amounts.
 }

--- a/snapshots/AllocatedBatchTransferTest.json
+++ b/snapshots/AllocatedBatchTransferTest.json
@@ -1,4 +1,4 @@
 {
-  "BatchTransfer": "119577",
-  "splitBatchWithdrawal": "148415"
+  "BatchTransfer": "124435",
+  "batchWithdrawal": "155298"
 }

--- a/snapshots/AllocatedTransferTest.json
+++ b/snapshots/AllocatedTransferTest.json
@@ -1,5 +1,5 @@
 {
-  "Transfer": "89699",
-  "qualified_basicTransfer": "62521",
-  "splitWithdrawal": "98651"
+  "Transfer": "93249",
+  "allocatedWithdrawal": "105719",
+  "qualified_basicTransfer": "66548"
 }

--- a/snapshots/ClaimTest.json
+++ b/snapshots/ClaimTest.json
@@ -1,5 +1,5 @@
 {
-  "claimAndWithdraw": "116808",
-  "splitBatchClaimWithWitness": "148360",
-  "splitClaimWithWitness": "92446"
+  "claimAndWithdraw": "121533",
+  "splitBatchClaimWithWitness": "155067",
+  "splitClaimWithWitness": "96905"
 }

--- a/snapshots/DepositAndRegisterForTest.json
+++ b/snapshots/DepositAndRegisterForTest.json
@@ -1,5 +1,5 @@
 {
-  "batchDepositRegisterFor": "79518",
-  "depositNativeAndRegisterFor": "50632",
-  "depositRegisterFor": "78508"
+  "batchDepositRegisterFor": "82889",
+  "depositNativeAndRegisterFor": "51436",
+  "depositRegisterFor": "81972"
 }

--- a/snapshots/DepositAndRegisterTest.json
+++ b/snapshots/DepositAndRegisterTest.json
@@ -1,5 +1,5 @@
 {
-  "batchDepositAndRegisterMultiple": "51130",
-  "depositERC20AndRegister": "85019",
-  "depositNativeAndRegister": "49071"
+  "batchDepositAndRegisterMultiple": "51361",
+  "depositERC20AndRegister": "88294",
+  "depositNativeAndRegister": "50265"
 }

--- a/snapshots/DepositTest.json
+++ b/snapshots/DepositTest.json
@@ -1,8 +1,8 @@
 {
-  "depositBatchSingleERC20": "66418",
-  "depositBatchSingleNative": "26824",
-  "depositERC20AndURI": "66036",
-  "depositERC20Basic": "66036",
-  "depositETHAndURI": "26077",
-  "depositETHBasic": "26077"
+  "depositBatchSingleERC20": "68913",
+  "depositBatchSingleNative": "27079",
+  "depositERC20AndURI": "68667",
+  "depositERC20Basic": "68667",
+  "depositETHAndURI": "26160",
+  "depositETHBasic": "26160"
 }

--- a/snapshots/EmissaryTest.json
+++ b/snapshots/EmissaryTest.json
@@ -1,9 +1,9 @@
 {
-  "assignEmissary": "24943",
-  "disableEmissary": "3049",
-  "getEmissaryStatus_disabled": "2857",
-  "getEmissaryStatus_enabled": "892",
-  "getEmissaryStatus_scheduled": "912",
-  "reassignEmissary": "3068",
-  "scheduleEmissaryAssignment": "3536"
+  "assignEmissary": "26538",
+  "disableEmissary": "4808",
+  "getEmissaryStatus_disabled": "4212",
+  "getEmissaryStatus_enabled": "2243",
+  "getEmissaryStatus_scheduled": "2266",
+  "reassignEmissary": "4848",
+  "scheduleEmissaryAssignment": "3666"
 }

--- a/snapshots/ForcedWithdrawalTest.json
+++ b/snapshots/ForcedWithdrawalTest.json
@@ -1,10 +1,10 @@
 {
-  "disableForcedWithdrawal": "3340",
-  "enableForcedWithdrawal": "25628",
-  "getForcedWithdrawalStatus_disabled": "2715",
-  "getForcedWithdrawalStatus_enabled": "715",
-  "getForcedWithdrawalStatus_pending": "715",
-  "processForcedWithdrawal": "38493",
-  "processForcedWithdrawal_erc20Token": "30788",
-  "processForcedWithdrawal_fullBalance": "38493"
+  "disableForcedWithdrawal": "3276",
+  "enableForcedWithdrawal": "25247",
+  "getForcedWithdrawalStatus_disabled": "3459",
+  "getForcedWithdrawalStatus_enabled": "1459",
+  "getForcedWithdrawalStatus_pending": "1459",
+  "processForcedWithdrawal": "39331",
+  "processForcedWithdrawal_erc20Token": "33252",
+  "processForcedWithdrawal_fullBalance": "39331"
 }

--- a/snapshots/MultichainClaimTest.json
+++ b/snapshots/MultichainClaimTest.json
@@ -1,6 +1,6 @@
 {
-  "exogenousSplitBatchMultichainClaimWithWitness": "122960",
-  "exogenousSplitMultichainClaimWithWitness": "93798",
-  "splitBatchMultichainClaimWithWitness": "95174",
-  "splitMultichainClaimWithWitness": "94026"
+  "batchMultichainClaimWithWitness": "99440",
+  "exogenousBatchMultichainClaimWithWitness": "128044",
+  "exogenousMultichainClaimWithWitness": "98356",
+  "multichainClaimWithWitness": "97618"
 }

--- a/snapshots/Permit2DepositAndRegisterTest.json
+++ b/snapshots/Permit2DepositAndRegisterTest.json
@@ -1,6 +1,6 @@
 {
-  "batchClaimRegisteredWithDepositWithWitness": "148360",
-  "batchDepositAndRegisterWithWitnessViaPermit2": "208346",
-  "claim": "89292",
-  "depositAndRegisterViaPermit2": "117311"
+  "batchClaimRegisteredWithDepositWithWitness": "155067",
+  "batchDepositAndRegisterWithWitnessViaPermit2": "215758",
+  "claim": "93791",
+  "depositAndRegisterViaPermit2": "121203"
 }

--- a/snapshots/Permit2DepositTest.json
+++ b/snapshots/Permit2DepositTest.json
@@ -1,5 +1,5 @@
 {
-  "depositBatchViaPermit2NativeAndERC20": "122397",
-  "depositBatchViaPermit2SingleERC20": "97559",
-  "depositERC20ViaPermit2AndURI": "93450"
+  "depositBatchViaPermit2NativeAndERC20": "126339",
+  "depositBatchViaPermit2SingleERC20": "101292",
+  "depositERC20ViaPermit2AndURI": "96203"
 }

--- a/snapshots/RegisterTest.json
+++ b/snapshots/RegisterTest.json
@@ -1,5 +1,5 @@
 {
-  "claim": "89292",
-  "registeMultiple": "25337",
-  "register": "24458"
+  "claim": "93791",
+  "registeMultiple": "25061",
+  "register": "24843"
 }

--- a/snapshots/TheCompactTest.json
+++ b/snapshots/TheCompactTest.json
@@ -1,3 +1,3 @@
 {
-  "claimAndWithdraw": "117148"
+  "claimAndWithdraw": "123536"
 }

--- a/src/TheCompact.sol
+++ b/src/TheCompact.sol
@@ -65,11 +65,11 @@ contract TheCompact is ITheCompact, ERC6909, TheCompactLogic {
     }
 
     function allocatedTransfer(AllocatedTransfer calldata transfer) external returns (bool) {
-        return _processSplitTransfer(transfer);
+        return _processTransfer(transfer);
     }
 
     function allocatedBatchTransfer(AllocatedBatchTransfer calldata transfer) external returns (bool) {
-        return _processSplitBatchTransfer(transfer);
+        return _processBatchTransfer(transfer);
     }
 
     function register(bytes32 claimHash, bytes32 typehash) external returns (bool) {

--- a/src/lib/ClaimHashLib.sol
+++ b/src/lib/ClaimHashLib.sol
@@ -55,11 +55,11 @@ library ClaimHashLib {
 
     ///// CATEGORY 1: Transfer claim hashes /////
     function toClaimHash(AllocatedTransfer calldata transfer) internal view returns (bytes32 claimHash) {
-        return transfer.toSplitTransferMessageHash();
+        return transfer.toTransferMessageHash();
     }
 
     function toClaimHash(AllocatedBatchTransfer calldata transfer) internal view returns (bytes32 claimHash) {
-        return transfer.toSplitBatchTransferMessageHash();
+        return transfer.toBatchTransferMessageHash();
     }
 
     ///// CATEGORY 2: Claim with witness message & type hashes /////
@@ -68,8 +68,7 @@ library ClaimHashLib {
     }
 
     function toMessageHashes(BatchClaim calldata claim) internal view returns (bytes32 claimHash, bytes32 typehash) {
-        return
-            HashLib.toBatchClaimWithWitnessMessageHash.usingBatchClaim()(claim, claim.claims.toSplitIdsAndAmountsHash());
+        return HashLib.toBatchClaimWithWitnessMessageHash.usingBatchClaim()(claim, claim.claims.toIdsAndAmountsHash());
     }
 
     function toMessageHashes(MultichainClaim calldata claim)
@@ -86,7 +85,7 @@ library ClaimHashLib {
         returns (bytes32 claimHash, bytes32 typehash)
     {
         return _toGenericMultichainClaimWithWitnessMessageHash.usingBatchMultichainClaim()(
-            claim, claim.claims.toSplitIdsAndAmountsHash(), HashLib.toMultichainClaimMessageHash
+            claim, claim.claims.toIdsAndAmountsHash(), HashLib.toMultichainClaimMessageHash
         );
     }
 
@@ -104,7 +103,7 @@ library ClaimHashLib {
         returns (bytes32 claimHash, bytes32 typehash)
     {
         return _toGenericMultichainClaimWithWitnessMessageHash.usingExogenousBatchMultichainClaim()(
-            claim, claim.claims.toSplitIdsAndAmountsHash(), HashLib.toExogenousMultichainClaimMessageHash
+            claim, claim.claims.toIdsAndAmountsHash(), HashLib.toExogenousMultichainClaimMessageHash
         );
     }
 

--- a/src/lib/ClaimProcessorFunctionCastLib.sol
+++ b/src/lib/ClaimProcessorFunctionCastLib.sol
@@ -24,7 +24,7 @@ library ClaimProcessorFunctionCastLib {
     /**
      * @notice Function cast to provide a Claim calldata struct while
      * treating it as a uint256 representing a calldata pointer location.
-     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleSplitClaim`.
+     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleClaim`.
      * @return fnOut Modified function used in `ClaimProcessorLogic._processClaim`.
      */
     function usingClaim(function(bytes32, uint256, uint256, bytes32, bytes32) internal fnIn)
@@ -40,7 +40,7 @@ library ClaimProcessorFunctionCastLib {
     /**
      * @notice Function cast to provide a BatchClaim calldata struct while
      * treating it as a uint256 representing a calldata pointer location.
-     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleSplitBatchClaim`.
+     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleBatchClaim`.
      * @return fnOut Modified function used in `ClaimProcessorLogic._processBatchClaim`.
      */
     function usingBatchClaim(function(bytes32, uint256, uint256, bytes32, bytes32) internal fnIn)
@@ -56,7 +56,7 @@ library ClaimProcessorFunctionCastLib {
     /**
      * @notice Function cast to provide a MultichainClaim calldata struct while
      * treating it as a uint256 representing a calldata pointer location.
-     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleSplitClaim`.
+     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleClaim`.
      * @return fnOut Modified function used in `ClaimProcessorLogic._processMultichainClaim`.
      */
     function usingMultichainClaim(function(bytes32, uint256, uint256, bytes32, bytes32) internal fnIn)
@@ -72,7 +72,7 @@ library ClaimProcessorFunctionCastLib {
     /**
      * @notice Function cast to provide a BatchMultichainClaim calldata struct while
      * treating it as a uint256 representing a calldata pointer location.
-     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleSplitBatchClaim`.
+     * @param fnIn   Function pointer to `ClaimProcessorLib.processSimpleBatchClaim`.
      * @return fnOut Modified function used in `ClaimProcessorLogic._processBatchMultichainClaim`.
      */
     function usingBatchMultichainClaim(function(bytes32, uint256, uint256, bytes32, bytes32) internal fnIn)
@@ -88,15 +88,13 @@ library ClaimProcessorFunctionCastLib {
     /**
      * @notice Function cast to provide a ExogenousMultichainClaim calldata struct while
      * treating it as a uint256 representing a calldata pointer location.
-     * @param fnIn   Function pointer to `ClaimProcessorLib.processSplitClaimWithSponsorDomain`.
+     * @param fnIn   Function pointer to `ClaimProcessorLib.processClaimWithSponsorDomain`.
      * @return fnOut Modified function used in `ClaimProcessorLogic._processExogenousMultichainClaim`.
      */
-    function usingExogenousMultichainClaim(function(bytes32, uint256, uint256, bytes32, bytes32, bytes32) internal fnIn)
+    function usingExogenousMultichainClaim(function(bytes32, uint256, bytes32, bytes32, bytes32) internal fnIn)
         internal
         pure
-        returns (
-            function(bytes32, ExogenousMultichainClaim calldata, uint256, bytes32, bytes32, bytes32) internal fnOut
-        )
+        returns (function(bytes32, ExogenousMultichainClaim calldata, bytes32, bytes32, bytes32) internal fnOut)
     {
         assembly ("memory-safe") {
             fnOut := fnIn
@@ -106,17 +104,13 @@ library ClaimProcessorFunctionCastLib {
     /**
      * @notice Function cast to provide a ExogenousBatchMultichainClaim calldata struct while
      * treating it as a uint256 representing a calldata pointer location.
-     * @param fnIn   Function pointer to `ClaimProcessorLib.processSplitBatchClaimWithSponsorDomain`.
+     * @param fnIn   Function pointer to `ClaimProcessorLib.processBatchClaimWithSponsorDomain`.
      * @return fnOut Modified function used in `ClaimProcessorLogic._processExogenousBatchMultichainClaim`.
      */
-    function usingExogenousBatchMultichainClaim(
-        function(bytes32, uint256, uint256, bytes32, bytes32, bytes32) internal fnIn
-    )
+    function usingExogenousBatchMultichainClaim(function(bytes32, uint256, bytes32, bytes32, bytes32) internal fnIn)
         internal
         pure
-        returns (
-            function(bytes32, ExogenousBatchMultichainClaim calldata, uint256, bytes32, bytes32, bytes32) internal fnOut
-        )
+        returns (function(bytes32, ExogenousBatchMultichainClaim calldata, bytes32, bytes32, bytes32) internal fnOut)
     {
         assembly ("memory-safe") {
             fnOut := fnIn

--- a/src/lib/ClaimProcessorLib.sol
+++ b/src/lib/ClaimProcessorLib.sol
@@ -153,31 +153,31 @@ library ClaimProcessorLib {
     }
 
     /**
-     * @notice Internal function for processing simple split claims with local domain
-     * signatures. Extracts split claim parameters from calldata, validates the claim,
-     * and executes operations for multiple recipients. Uses the message hash itself as
-     * the qualification message and a zero sponsor domain separator.
+     * @notice Internal function for processing simple claims with local domain
+     * signatures. Extracts claim parameters from calldata, validates the claim,
+     * and executes operations for multiple recipients. Uses the zero sponsor
+     * domain separator.
      * @param messageHash      The EIP-712 hash of the claim message.
      * @param calldataPointer  Pointer to the location of the associated struct in calldata.
      * @param offsetToId       Offset to segment of calldata where relevant claim parameters begin.
      * @param typehash         The EIP-712 typehash used for the claim message.
      * @param domainSeparator  The local domain separator.
      */
-    function processSimpleSplitClaim(
+    function processSimpleClaim(
         bytes32 messageHash,
         uint256 calldataPointer,
         uint256 offsetToId,
         bytes32 typehash,
         bytes32 domainSeparator
     ) internal {
-        messageHash.processClaimWithSplitComponents(
+        messageHash.processClaimWithComponents(
             calldataPointer, offsetToId, bytes32(0).asStubborn(), typehash, domainSeparator, validate
         );
     }
 
     /**
-     * @notice Internal function for processing simple split batch claims with local domain
-     * signatures. Extracts split batch claim parameters from calldata, validates the claim,
+     * @notice Internal function for processing simple batch claims with local domain
+     * signatures. Extracts batch claim parameters from calldata, validates the claim,
      * and executes operations for multiple resource locks to multiple recipients. Uses the
      * message hash itself as the qualification message and a zero sponsor domain separator.
      * @param messageHash      The EIP-712 hash of the claim message.
@@ -186,66 +186,62 @@ library ClaimProcessorLib {
      * @param typehash         The EIP-712 typehash used for the claim message.
      * @param domainSeparator  The local domain separator.
      */
-    function processSimpleSplitBatchClaim(
+    function processSimpleBatchClaim(
         bytes32 messageHash,
         uint256 calldataPointer,
         uint256 offsetToId,
         bytes32 typehash,
         bytes32 domainSeparator
     ) internal {
-        messageHash.processClaimWithSplitBatchComponents(
+        messageHash.processClaimWithBatchComponents(
             calldataPointer, offsetToId, bytes32(0).asStubborn(), typehash, domainSeparator, validate
         );
     }
 
     /**
-     * @notice Internal function for processing split claims with sponsor domain signatures.
-     * Extracts split claim parameters from calldata, validates the claim using the provided
+     * @notice Internal function for processing claims with sponsor domain signatures.
+     * Extracts claim parameters from calldata, validates the claim using the provided
      * sponsor domain, and executes operations for multiple recipients. Uses the message
      * hash itself as the qualification message.
      * @param messageHash      The EIP-712 hash of the claim message.
      * @param calldataPointer  Pointer to the location of the associated struct in calldata.
-     * @param offsetToId       Offset to segment of calldata where relevant claim parameters begin.
      * @param sponsorDomain    The domain separator for the sponsor's signature.
      * @param typehash         The EIP-712 typehash used for the claim message.
      * @param domainSeparator  The local domain separator.
      */
-    function processSplitClaimWithSponsorDomain(
+    function processClaimWithSponsorDomain(
         bytes32 messageHash,
         uint256 calldataPointer,
-        uint256 offsetToId,
         bytes32 sponsorDomain,
         bytes32 typehash,
         bytes32 domainSeparator
     ) internal {
-        messageHash.processClaimWithSplitComponents(
-            calldataPointer, offsetToId, sponsorDomain, typehash, domainSeparator, validate
+        messageHash.processClaimWithComponents(
+            calldataPointer, 0x140, sponsorDomain, typehash, domainSeparator, validate
         );
     }
 
     /**
-     * @notice Internal function for processing split batch claims with sponsor domain
-     * signatures. Extracts split batch claim parameters from calldata, validates the claim
+     * @notice Internal function for processing batch claims with sponsor domain
+     * signatures. Extracts batch claim parameters from calldata, validates the claim
      * using the provided sponsor domain, and executes operations for multiple resource
      * locks to multiple recipients. Uses the message hash itself as the qualification
      * message.
      * @param messageHash      The EIP-712 hash of the claim message.
      * @param calldataPointer  Pointer to the location of the associated struct in calldata.
-     * @param offsetToId       Offset to segment of calldata where relevant claim parameters begin.
      * @param sponsorDomain    The domain separator for the sponsor's signature.
      * @param typehash         The EIP-712 typehash used for the claim message.
      * @param domainSeparator  The local domain separator.
      */
-    function processSplitBatchClaimWithSponsorDomain(
+    function processBatchClaimWithSponsorDomain(
         bytes32 messageHash,
         uint256 calldataPointer,
-        uint256 offsetToId,
         bytes32 sponsorDomain,
         bytes32 typehash,
         bytes32 domainSeparator
     ) internal {
-        messageHash.processClaimWithSplitBatchComponents(
-            calldataPointer, offsetToId, sponsorDomain, typehash, domainSeparator, validate
+        messageHash.processClaimWithBatchComponents(
+            calldataPointer, 0x140, sponsorDomain, typehash, domainSeparator, validate
         );
     }
 }

--- a/src/lib/ClaimProcessorLogic.sol
+++ b/src/lib/ClaimProcessorLogic.sol
@@ -32,6 +32,7 @@ contract ClaimProcessorLogic is ConstructorLogic {
     using ClaimHashLib for BatchMultichainClaim;
     using ClaimHashLib for ExogenousBatchMultichainClaim;
     using ClaimProcessorLib for uint256;
+    using ClaimProcessorFunctionCastLib for function(bytes32, uint256, bytes32, bytes32, bytes32) internal;
     using ClaimProcessorFunctionCastLib for function(bytes32, uint256, uint256, bytes32, bytes32) internal;
     using ClaimProcessorFunctionCastLib for function(bytes32, uint256, uint256, bytes32, bytes32, bytes32) internal;
     using ClaimProcessorFunctionCastLib for function(bytes32, bytes32, uint256, uint256, bytes32, bytes32) internal;
@@ -49,9 +50,7 @@ contract ClaimProcessorLogic is ConstructorLogic {
 
         bytes32 typehash;
         (claimHash, typehash) = claimPayload.toMessageHashes();
-        ClaimProcessorLib.processSimpleSplitClaim.usingClaim()(
-            claimHash, claimPayload, 0xe0, typehash, _domainSeparator()
-        );
+        ClaimProcessorLib.processSimpleClaim.usingClaim()(claimHash, claimPayload, 0xe0, typehash, _domainSeparator());
 
         // Clear the reentrancy guard.
         _clearReentrancyGuard();
@@ -64,7 +63,7 @@ contract ClaimProcessorLogic is ConstructorLogic {
 
         bytes32 typehash;
         (claimHash, typehash) = claimPayload.toMessageHashes();
-        ClaimProcessorLib.processSimpleSplitBatchClaim.usingBatchClaim()(
+        ClaimProcessorLib.processSimpleBatchClaim.usingBatchClaim()(
             claimHash, claimPayload, uint256(0xe0).asStubborn(), typehash, _domainSeparator()
         );
 
@@ -79,7 +78,7 @@ contract ClaimProcessorLogic is ConstructorLogic {
 
         bytes32 typehash;
         (claimHash, typehash) = claimPayload.toMessageHashes();
-        ClaimProcessorLib.processSimpleSplitClaim.usingMultichainClaim()(
+        ClaimProcessorLib.processSimpleClaim.usingMultichainClaim()(
             claimHash, claimPayload, 0x100, typehash, _domainSeparator()
         );
 
@@ -97,7 +96,7 @@ contract ClaimProcessorLogic is ConstructorLogic {
 
         bytes32 typehash;
         (claimHash, typehash) = claimPayload.toMessageHashes();
-        ClaimProcessorLib.processSimpleSplitBatchClaim.usingBatchMultichainClaim()(
+        ClaimProcessorLib.processSimpleBatchClaim.usingBatchMultichainClaim()(
             claimHash, claimPayload, uint256(0x100).asStubborn(), typehash, _domainSeparator()
         );
 
@@ -115,10 +114,9 @@ contract ClaimProcessorLogic is ConstructorLogic {
 
         bytes32 typehash;
         (claimHash, typehash) = claimPayload.toMessageHashes();
-        ClaimProcessorLib.processSplitClaimWithSponsorDomain.usingExogenousMultichainClaim()(
+        ClaimProcessorLib.processClaimWithSponsorDomain.usingExogenousMultichainClaim()(
             claimHash,
             claimPayload,
-            0x140,
             claimPayload.notarizedChainId.toNotarizedDomainSeparator(),
             typehash,
             _domainSeparator()
@@ -138,10 +136,9 @@ contract ClaimProcessorLogic is ConstructorLogic {
 
         bytes32 typehash;
         (claimHash, typehash) = claimPayload.toMessageHashes();
-        ClaimProcessorLib.processSplitBatchClaimWithSponsorDomain.usingExogenousBatchMultichainClaim()(
+        ClaimProcessorLib.processBatchClaimWithSponsorDomain.usingExogenousBatchMultichainClaim()(
             claimHash,
             claimPayload,
-            0x140,
             claimPayload.notarizedChainId.toNotarizedDomainSeparator(),
             typehash,
             _domainSeparator()

--- a/src/lib/HashLib.sol
+++ b/src/lib/HashLib.sol
@@ -37,7 +37,6 @@ import { TransferFunctionCastLib } from "./TransferFunctionCastLib.sol";
 library HashLib {
     using EfficiencyLib for bool;
     using EfficiencyLib for uint256;
-    using TransferFunctionCastLib for function(AllocatedTransfer calldata, uint256) internal view returns (bytes32);
     using HashLib for uint256;
     using HashLib for uint256[2][];
     using HashLib for AllocatedBatchTransfer;
@@ -48,11 +47,7 @@ library HashLib {
      * @param transfer     An AllocatedTransfer struct containing the transfer details.
      * @return messageHash The EIP-712 compliant message hash.
      */
-    function toSplitTransferMessageHash(AllocatedTransfer calldata transfer)
-        internal
-        view
-        returns (bytes32 messageHash)
-    {
+    function toTransferMessageHash(AllocatedTransfer calldata transfer) internal view returns (bytes32 messageHash) {
         // Declare variables for tracking, total amount, current amount, and errors.
         uint256 amount = 0;
         uint256 currentAmount;
@@ -110,11 +105,7 @@ library HashLib {
      * @param transfer     An AllocatedBatchTransfer struct containing the transfer details.
      * @return messageHash The EIP-712 compliant message hash.
      */
-    function toSplitBatchTransferMessageHash(AllocatedBatchTransfer calldata transfer)
-        internal
-        view
-        returns (bytes32)
-    {
+    function toBatchTransferMessageHash(AllocatedBatchTransfer calldata transfer) internal view returns (bytes32) {
         // Navigate to the transfer components array in calldata.
         ComponentsById[] calldata transfers = transfer.transfers;
 
@@ -597,7 +588,7 @@ library HashLib {
      * @param claims             An array of BatchClaimComponent structs.
      * @return idsAndAmountsHash The hash of the ids and amounts.
      */
-    function toSplitIdsAndAmountsHash(BatchClaimComponent[] calldata claims)
+    function toIdsAndAmountsHash(BatchClaimComponent[] calldata claims)
         internal
         pure
         returns (uint256 idsAndAmountsHash)

--- a/src/lib/TransferFunctionCastLib.sol
+++ b/src/lib/TransferFunctionCastLib.sol
@@ -20,36 +20,14 @@ library TransferFunctionCastLib {
      * @notice Function cast to provide a BatchTransfer calldata struct while
      * treating it as a BasicTransfer calldata struct.
      * @param fnIn   Function pointer to `TransferLogic._notExpiredAndAuthorizedByAllocator`.
-     * @return fnOut Modified function used in `TransferLogic._processSplitBatchTransfer`.
+     * @return fnOut Modified function used in `TransferLogic._processBatchTransfer`.
      */
-    function usingSplitBatchTransfer(
+    function usingBatchTransfer(
         function (bytes32, address, AllocatedTransfer calldata, uint256[2][] memory) internal fnIn
     )
         internal
         pure
         returns (function (bytes32, address, AllocatedBatchTransfer calldata, uint256[2][] memory) internal fnOut)
-    {
-        assembly ("memory-safe") {
-            fnOut := fnIn
-        }
-    }
-
-    /**
-     * @notice Function cast to provide a ComponentsById array while treating it
-     * as a TransferComponent array.
-     * @param fnIn   Function pointer to `TransferLogic._deriveConsistentAllocatorAndConsumeNonce`.
-     * @return fnOut Modified function used in `TransferLogic._processSplitBatchTransfer`.
-     */
-    function usingSplitByIdComponent(
-        function(TransferComponent[] calldata, uint256, function (TransferComponent[] calldata, uint256) internal pure returns (uint96)) internal returns (address)
-            fnIn
-    )
-        internal
-        pure
-        returns (
-            function(ComponentsById[] calldata, uint256, function (ComponentsById[] calldata, uint256) internal pure returns (uint96)) internal returns (address)
-            fnOut
-        )
     {
         assembly ("memory-safe") {
             fnOut := fnIn

--- a/src/types/BatchMultichainClaims.sol
+++ b/src/types/BatchMultichainClaims.sol
@@ -11,7 +11,7 @@ struct BatchMultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
+    bytes32[] additionalChains; // The element hashes from additional chains.
     BatchClaimComponent[] claims; // The claim token IDs, recipients and amounts.
 }
 
@@ -23,8 +23,8 @@ struct ExogenousBatchMultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
-    uint256 chainIndex; // The index after which to insert the current allocation hash.
+    bytes32[] additionalChains; // The element hashes from additional chains.
+    uint256 chainIndex; // The index after which to insert the current element hash.
     uint256 notarizedChainId; // The chain id used to sign the multichain claim.
     BatchClaimComponent[] claims; // The claim token IDs, recipients and amounts.
 }

--- a/src/types/MultichainClaims.sol
+++ b/src/types/MultichainClaims.sol
@@ -11,7 +11,7 @@ struct MultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
+    bytes32[] additionalChains; // The element hashes from additional chains.
     uint256 id; // The token ID of the ERC6909 token to allocate.
     uint256 allocatedAmount; // The original allocated amount of ERC6909 tokens.
     Component[] claimants; // The claim recipients and amounts; specified by the arbiter.
@@ -25,8 +25,8 @@ struct ExogenousMultichainClaim {
     uint256 expires; // The time at which the claim expires.
     bytes32 witness; // Hash of the witness data.
     string witnessTypestring; // Witness typestring appended to existing typestring.
-    bytes32[] additionalChains; // The allocation hashes from additional chains.
-    uint256 chainIndex; // The index after which to insert the current allocation hash.
+    bytes32[] additionalChains; // The element hashes from additional chains.
+    uint256 chainIndex; // The index after which to insert the current element hash.
     uint256 notarizedChainId; // The chain id used to sign the multichain claim.
     uint256 id; // The token ID of the ERC6909 token to allocate.
     uint256 allocatedAmount; // The original allocated amount of ERC6909 tokens.

--- a/test/integration/AllocatedBatchTransfer.t.sol
+++ b/test/integration/AllocatedBatchTransfer.t.sol
@@ -247,7 +247,7 @@ contract AllocatedBatchTransferTest is Setup {
         {
             vm.prank(swapper);
             bool status = theCompact.allocatedBatchTransfer(transfer);
-            vm.snapshotGasLastCall("splitBatchWithdrawal");
+            vm.snapshotGasLastCall("batchWithdrawal");
             assert(status);
         }
 

--- a/test/integration/AllocatedTransfer.t.sol
+++ b/test/integration/AllocatedTransfer.t.sol
@@ -62,12 +62,12 @@ contract AllocatedTransferTest is Setup {
             uint256 claimantOne = abi.decode(abi.encodePacked(bytes12(bytes32(id)), recipientOne), (uint256));
             uint256 claimantTwo = abi.decode(abi.encodePacked(bytes12(bytes32(id)), recipientTwo), (uint256));
 
-            Component memory splitOne = Component({ claimant: claimantOne, amount: amountOne });
-            Component memory splitTwo = Component({ claimant: claimantTwo, amount: amountTwo });
+            Component memory componentOne = Component({ claimant: claimantOne, amount: amountOne });
+            Component memory componentTwo = Component({ claimant: claimantTwo, amount: amountTwo });
 
             recipients = new Component[](2);
-            recipients[0] = splitOne;
-            recipients[1] = splitTwo;
+            recipients[0] = componentOne;
+            recipients[1] = componentTwo;
         }
 
         // Create and execute transfer
@@ -152,10 +152,10 @@ contract AllocatedTransferTest is Setup {
         {
             uint256 claimant = abi.decode(abi.encodePacked(bytes12(bytes32(id)), params.recipient), (uint256));
 
-            Component memory split = Component({ claimant: claimant, amount: params.amount });
+            Component memory component = Component({ claimant: claimant, amount: params.amount });
 
             recipients = new Component[](1);
-            recipients[0] = split;
+            recipients[0] = component;
         }
 
         // Create and execute transfer
@@ -235,15 +235,15 @@ contract AllocatedTransferTest is Setup {
             }
 
             {
-                Component memory splitOne;
-                Component memory splitTwo;
+                Component memory componentOne;
+                Component memory componentTwo;
 
-                splitOne = Component({ claimant: claimantOne, amount: amountOne });
-                splitTwo = Component({ claimant: claimantTwo, amount: amountTwo });
+                componentOne = Component({ claimant: claimantOne, amount: amountOne });
+                componentTwo = Component({ claimant: claimantTwo, amount: amountTwo });
 
                 recipients = new Component[](2);
-                recipients[0] = splitOne;
-                recipients[1] = splitTwo;
+                recipients[0] = componentOne;
+                recipients[1] = componentTwo;
             }
         }
 
@@ -263,7 +263,7 @@ contract AllocatedTransferTest is Setup {
             {
                 vm.prank(swapper);
                 bool status = theCompact.allocatedTransfer(transfer);
-                vm.snapshotGasLastCall("splitWithdrawal");
+                vm.snapshotGasLastCall("allocatedWithdrawal");
                 assert(status);
             }
         }

--- a/test/integration/Claim.t.sol
+++ b/test/integration/Claim.t.sol
@@ -17,7 +17,7 @@ import {
     TestParams,
     CreateClaimHashWithWitnessArgs,
     CreateBatchClaimHashWithWitnessArgs,
-    SplitBatchMultichainClaimArgs
+    BatchMultichainClaimArgs
 } from "./TestHelperStructs.sol";
 
 contract ClaimTest is Setup {

--- a/test/integration/TestHelperStructs.sol
+++ b/test/integration/TestHelperStructs.sol
@@ -73,7 +73,7 @@ struct LockDetails {
     bytes12 lockTag;
 }
 
-struct SplitBatchMultichainClaimArgs {
+struct BatchMultichainClaimArgs {
     TestParams params;
     BatchMultichainClaim claim;
     uint256 anotherChainId;

--- a/test/lib/ComponentLib.t.sol
+++ b/test/lib/ComponentLib.t.sol
@@ -31,13 +31,13 @@ contract ComponentLibTester {
         return ComponentLib._buildIdsAndAmounts(claims, sponsorDomainSeparator);
     }
 
-    function verifyAndProcessSplitComponents(
+    function verifyAndProcessComponents(
         Component[] calldata claimants,
         address sponsor,
         uint256 id,
         uint256 allocatedAmount
     ) external {
-        claimants.verifyAndProcessSplitComponents(sponsor, id, allocatedAmount);
+        claimants.verifyAndProcessComponents(sponsor, id, allocatedAmount);
     }
 }
 
@@ -60,18 +60,18 @@ contract ComponentLibTest is Test {
         (allocatorId, lockTag) = _registerAllocator(ALLOCATOR);
     }
 
-    function testAggregate_Empty() public {
+    function testAggregate_Empty() public view {
         Component[] memory recipients = new Component[](0);
         assertEq(tester.aggregateComponents(recipients), 0, "Aggregate empty failed");
     }
 
-    function testAggregate_Single() public {
+    function testAggregate_Single() public view {
         Component[] memory recipients = new Component[](1);
         recipients[0] = Component({ claimant: _makeClaimant(CLAIMANT_1), amount: 100 });
         assertEq(tester.aggregateComponents(recipients), 100, "Aggregate single failed");
     }
 
-    function testAggregate_Multiple() public {
+    function testAggregate_Multiple() public view {
         Component[] memory recipients = new Component[](3);
         recipients[0] = Component({ claimant: _makeClaimant(CLAIMANT_1), amount: 100 });
         recipients[1] = Component({ claimant: _makeClaimant(CLAIMANT_2), amount: 250 });
@@ -129,7 +129,7 @@ contract ComponentLibTest is Test {
         return lock.toId();
     }
 
-    function testBuildIdsAndAmounts_Single() public {
+    function testBuildIdsAndAmounts_Single() public view {
         uint256 id = _buildTestId(ALLOCATOR, TOKEN, Scope.Multichain, ResetPeriod.OneDay);
         uint256 amount = 1000;
         Component[] memory portions = new Component[](1);
@@ -148,7 +148,7 @@ contract ComponentLibTest is Test {
         assertEq(shortestResetPeriod, uint256(ResetPeriod.OneDay), "Shortest period mismatch");
     }
 
-    function testBuildIdsAndAmounts_Multiple_Valid() public {
+    function testBuildIdsAndAmounts_Multiple_Valid() public view {
         uint256 id1 = _buildTestId(ALLOCATOR, TOKEN, Scope.Multichain, ResetPeriod.OneDay);
         uint256 id2 = _buildTestId(ALLOCATOR, address(0xcccc), Scope.Multichain, ResetPeriod.OneHourAndFiveMinutes);
         uint256 amount1 = 1000;
@@ -212,7 +212,7 @@ contract ComponentLibTest is Test {
         tester.buildIdsAndAmounts(claims, sponsorDomainSeparator);
     }
 
-    function testVerifyAndProcessSplitComponents_AmountExceedsAllocation() public {
+    function testVerifyAndProcessComponents_AmountExceedsAllocation() public {
         uint256 id = _buildTestId(ALLOCATOR, TOKEN, Scope.Multichain, ResetPeriod.OneDay);
         uint256 allocatedAmount = 300;
 
@@ -221,20 +221,20 @@ contract ComponentLibTest is Test {
         recipients[1] = Component({ claimant: _makeClaimant(CLAIMANT_2), amount: 250 });
 
         vm.expectRevert(InsufficientBalance.selector);
-        tester.verifyAndProcessSplitComponents(recipients, address(this), id, allocatedAmount);
+        tester.verifyAndProcessComponents(recipients, address(this), id, allocatedAmount);
     }
 
-    function testVerifyAndProcessSplitComponents_EmptyClaimants() public {
+    function testVerifyAndProcessComponents_EmptyClaimants() public {
         uint256 id = _buildTestId(ALLOCATOR, TOKEN, Scope.Multichain, ResetPeriod.OneDay);
         uint256 allocatedAmount = 100;
         Component[] memory recipients = new Component[](0);
 
         // Empty array sets the error buffer to 0, which causes a revert with AllocatedAmountExceeded
         vm.expectRevert(abi.encodeWithSelector(ITheCompact.AllocatedAmountExceeded.selector, allocatedAmount, 0));
-        tester.verifyAndProcessSplitComponents(recipients, address(this), id, allocatedAmount);
+        tester.verifyAndProcessComponents(recipients, address(this), id, allocatedAmount);
     }
 
-    function testVerifyAndProcessSplitComponents_Overflow() public {
+    function testVerifyAndProcessComponents_Overflow() public {
         uint256 id = _buildTestId(ALLOCATOR, TOKEN, Scope.Multichain, ResetPeriod.OneDay);
         uint256 allocatedAmount = type(uint256).max;
 
@@ -243,7 +243,7 @@ contract ComponentLibTest is Test {
         recipients[1] = Component({ claimant: _makeClaimant(CLAIMANT_2), amount: 1 });
 
         vm.expectRevert(InsufficientBalance.selector);
-        tester.verifyAndProcessSplitComponents(recipients, address(this), id, allocatedAmount);
+        tester.verifyAndProcessComponents(recipients, address(this), id, allocatedAmount);
     }
 
     function _makeClaimant(address _recipient) internal view returns (uint256) {

--- a/test/unit/Transfer/MockTransferLogic.sol
+++ b/test/unit/Transfer/MockTransferLogic.sol
@@ -42,12 +42,12 @@ contract MockTransferLogic is TheCompactLogic {
         (id,) = _performCustomERC20Deposit(token, lockTag, amount, recipient.usingCallerIfNull());
     }
 
-    function processSplitTransfer(AllocatedTransfer calldata transfer) external returns (bool) {
-        return _processSplitTransfer(transfer);
+    function processTransfer(AllocatedTransfer calldata transfer) external returns (bool) {
+        return _processTransfer(transfer);
     }
 
-    function processSplitBatchTransfer(AllocatedBatchTransfer calldata transfer) external returns (bool) {
-        return _processSplitBatchTransfer(transfer);
+    function processBatchTransfer(AllocatedBatchTransfer calldata transfer) external returns (bool) {
+        return _processBatchTransfer(transfer);
     }
 
     function ensureAttested(address from, address to, uint256 id, uint256 amount) external {

--- a/test/unit/Transfer/TransferLogic.t.sol
+++ b/test/unit/Transfer/TransferLogic.t.sol
@@ -69,10 +69,10 @@ contract TransferLogicTest is Test {
 
         // Process the transfer
         vm.prank(sponsor);
-        assertTrue(logic.processSplitTransfer(transfer), "Transfer should be successful");
+        assertTrue(logic.processTransfer(transfer), "Transfer should be successful");
     }
 
-    function test_processSplitBatchTransfer() public {
+    function test_processBatchTransfer() public {
         MockERC20 secondToken = new MockERC20("Second Token", "SECOND", 18);
         secondToken.mint(sponsor, 500);
         _makeDeposit(sponsor, address(secondToken), 500, lockTag);
@@ -110,7 +110,7 @@ contract TransferLogicTest is Test {
 
         // Process the batch transfer
         vm.prank(sponsor);
-        assertTrue(logic.processSplitBatchTransfer(batchTransfer), "Batch transfer should be successful");
+        assertTrue(logic.processBatchTransfer(batchTransfer), "Batch transfer should be successful");
     }
 
     function test_processSplitTransfer_expired() public {
@@ -130,10 +130,10 @@ contract TransferLogicTest is Test {
         // Process the transfer - should revert with ExpiredCompact
         vm.prank(sponsor);
         vm.expectRevert();
-        logic.processSplitTransfer(transfer);
+        logic.processTransfer(transfer);
     }
 
-    function test_processSplitTransfer_insufficientBalance() public {
+    function test_processTransfer_insufficientBalance() public {
         // Create components array requesting more than available
         Component[] memory recipients = new Component[](1);
         recipients[0] = Component({ claimant: _makeClaimant(recipient), amount: 1001 }); // More than the 1000 available
@@ -150,10 +150,10 @@ contract TransferLogicTest is Test {
         // Process the transfer - should revert with arithmetic error
         vm.prank(sponsor);
         vm.expectRevert();
-        logic.processSplitTransfer(transfer);
+        logic.processTransfer(transfer);
     }
 
-    function test_processSplitTransfer_zeroAmount() public {
+    function test_processTransfer_zeroAmount() public {
         // Create components array with zero amount
         Component[] memory recipients = new Component[](1);
         recipients[0] = Component({ claimant: _makeClaimant(recipient), amount: 0 });
@@ -170,10 +170,10 @@ contract TransferLogicTest is Test {
         // Reverts because zero amount is disallowed
         vm.expectRevert(abi.encodePacked(bytes4(keccak256("InsufficientBalance()"))));
         vm.prank(sponsor);
-        logic.processSplitTransfer(transfer);
+        logic.processTransfer(transfer);
     }
 
-    function test_processSplitTransfer_zeroRecipients() public {
+    function test_processTransfer_zeroRecipients() public {
         // Create empty components array
         Component[] memory recipients = new Component[](0);
 
@@ -188,7 +188,7 @@ contract TransferLogicTest is Test {
 
         // Process the transfer
         vm.prank(sponsor);
-        bool success = logic.processSplitTransfer(transfer);
+        bool success = logic.processTransfer(transfer);
 
         // Verify the transfer was "successful" but no tokens moved
         assertTrue(success, "Transfer should be 'successful'");
@@ -219,7 +219,7 @@ contract TransferLogicTest is Test {
         emit ERC6909.Transfer(sponsor, sponsor, recipient, testTokenId, 300);
 
         vm.prank(sponsor);
-        assertTrue(logic.processSplitTransfer(transfer), "Transfer should be successful");
+        assertTrue(logic.processTransfer(transfer), "Transfer should be successful");
     }
 
     function test_processSplitTransfer_maxRecipients() public {
@@ -245,7 +245,7 @@ contract TransferLogicTest is Test {
 
         // Process the transfer
         vm.prank(sponsor);
-        assertTrue(logic.processSplitTransfer(transfer), "Transfer should be successful");
+        assertTrue(logic.processTransfer(transfer), "Transfer should be successful");
     }
 
     function test_processSplitBatchTransfer_emptyTransfers() public {
@@ -263,7 +263,7 @@ contract TransferLogicTest is Test {
         // Process the batch transfer - should revert because of empty array check
         vm.prank(sponsor);
         vm.expectRevert();
-        logic.processSplitBatchTransfer(batchTransfer);
+        logic.processBatchTransfer(batchTransfer);
     }
 
     function test_processSplitBatchTransfer_mixedResults() public {
@@ -317,7 +317,7 @@ contract TransferLogicTest is Test {
         vm.expectRevert(abi.encodePacked(bytes4(keccak256("InsufficientBalance()"))));
 
         vm.prank(sponsor);
-        logic.processSplitBatchTransfer(batchTransfer);
+        logic.processBatchTransfer(batchTransfer);
     }
 
     function test_inconsistentAllocatorsInBatchTransfer() public {
@@ -359,7 +359,7 @@ contract TransferLogicTest is Test {
         // Should revert with inconsistent allocators
         vm.expectRevert();
         vm.prank(sponsor);
-        logic.processSplitBatchTransfer(batchTransfer);
+        logic.processBatchTransfer(batchTransfer);
     }
 
     function test_integerOverflowInAggregate() public {
@@ -379,7 +379,7 @@ contract TransferLogicTest is Test {
         // Should revert with arithmetic overflow
         vm.expectRevert();
         vm.prank(sponsor);
-        logic.processSplitTransfer(transfer);
+        logic.processTransfer(transfer);
     }
 
     function test_unusualTokenIdBitPatterns() public {
@@ -401,7 +401,7 @@ contract TransferLogicTest is Test {
         // Should either handle correctly or revert with a specific error
         vm.prank(sponsor);
         vm.expectRevert(); // Expect revert due to invalid token ID
-        logic.processSplitTransfer(transfer);
+        logic.processTransfer(transfer);
     }
 
     function _makeClaimant(address _recipient) internal view returns (uint256) {


### PR DESCRIPTION
- remove references to Split in function names
- remove references to "allocator hash" in comments
- remove a few unnecessary function casts
- remove a few unnecessary internal function arguments
- fix compiler warnings in tests