### PR TITLE
Feat/emissary claim hash

### DIFF
--- a/snapshots/ClaimTest.json
+++ b/snapshots/ClaimTest.json
@@ -1,5 +1,5 @@
 {
-  "claimAndWithdraw": "116808",
-  "splitBatchClaimWithWitness": "148390",
-  "splitClaimWithWitness": "92446"
+  "claimAndWithdraw": "116811",
+  "splitBatchClaimWithWitness": "148393",
+  "splitClaimWithWitness": "92449"
 }

--- a/snapshots/MultichainClaimTest.json
+++ b/snapshots/MultichainClaimTest.json
@@ -1,6 +1,6 @@
 {
-  "batchMultichainClaimWithWitness": "95204",
-  "exogenousBatchMultichainClaimWithWitness": "122936",
-  "exogenousMultichainClaimWithWitness": "93809",
-  "multichainClaimWithWitness": "94026"
+  "batchMultichainClaimWithWitness": "95207",
+  "exogenousBatchMultichainClaimWithWitness": "122939",
+  "exogenousMultichainClaimWithWitness": "93812",
+  "multichainClaimWithWitness": "94029"
 }

--- a/snapshots/Permit2DepositAndRegisterTest.json
+++ b/snapshots/Permit2DepositAndRegisterTest.json
@@ -1,6 +1,6 @@
 {
-  "batchClaimRegisteredWithDepositWithWitness": "148390",
+  "batchClaimRegisteredWithDepositWithWitness": "148393",
   "batchDepositAndRegisterWithWitnessViaPermit2": "208314",
-  "claim": "89292",
+  "claim": "89295",
   "depositAndRegisterViaPermit2": "117295"
 }

--- a/snapshots/RegisterTest.json
+++ b/snapshots/RegisterTest.json
@@ -1,5 +1,5 @@
 {
-  "claim": "89292",
+  "claim": "89295",
   "registeMultiple": "25337",
   "register": "24458"
 }

--- a/snapshots/TheCompactTest.json
+++ b/snapshots/TheCompactTest.json
@@ -1,3 +1,3 @@
 {
-  "claimAndWithdraw": "117148"
+  "claimAndWithdraw": "117156"
 }

--- a/src/lib/ValidityLib.sol
+++ b/src/lib/ValidityLib.sol
@@ -174,8 +174,8 @@ library ValidityLib {
             return;
         }
 
-        // Finally, fallback to emissary using the claim hash.
-        claimHash.verifyWithEmissary(expectedSigner, idsAndAmounts.extractSameLockTag(), signature);
+        // Finally, fallback to emissary using the digest
+        digest.verifyWithEmissary(expectedSigner, idsAndAmounts.extractSameLockTag(), signature);
     }
 
     /**


### PR DESCRIPTION
I think we should reconsider passing the claimHash to the emissary. but instead pass the digest (notarizedChainDomainSep + claimHash). 

the reason why I think the current implementation is a bit weird, is cause the claimHash will be the same on all chains. then getting the same digest within the emissary gets kinda tricky, since the emissary doesn't know which chain the notarized chain is. This could nudge emissary developers in providing the notarizedChainID packed in the signature or so, which could be a security issue.

alternatively, we could also provide the notarizedChainID to the emissary, but I personally prefer passing in the digest instead