### PR TITLE
fix(N-17): remove `toRegisteredAllocatorWithConsumed`

### DIFF
--- a/src/lib/TransferLogic.sol
+++ b/src/lib/TransferLogic.sol
@@ -60,7 +60,7 @@ contract TransferLogic is ConstructorLogic {
         // Derive hash, validate expiry, consume nonce, and check allocator signature.
         _notExpiredAndAuthorizedByAllocator(
             transfer.toClaimHash(),
-            transfer.id.toRegisteredAllocatorWithConsumed(transfer.nonce),
+            transfer.id.toAllocatorId().fromRegisteredAllocatorIdWithConsumed(transfer.nonce),
             transfer,
             idsAndAmounts
         );

--- a/src/lib/ValidityLib.sol
+++ b/src/lib/ValidityLib.sol
@@ -49,18 +49,6 @@ library ValidityLib {
     }
 
     /**
-     * @notice Internal function that retrieves an allocator's address from a resource lock ID
-     * and consumes a nonce in their scope. Reverts if the allocator is not registered.
-     * @param id         The ERC6909 token identifier containing the allocator ID.
-     * @param nonce      The nonce to consume in the allocator's scope.
-     * @return allocator The address of the registered allocator.
-     */
-    function toRegisteredAllocatorWithConsumed(uint256 id, uint256 nonce) internal returns (address allocator) {
-        allocator = id.toAllocatorId().toRegisteredAllocator();
-        nonce.consumeNonceAsAllocator(allocator);
-    }
-
-    /**
      * @notice Internal view function that ensures that a timestamp has not yet passed.
      * Reverts if the provided timestamp is not in the future.
      * @param expires The timestamp to check.


### PR DESCRIPTION
Removed the single-use `toRegisteredAllocatorWithConsumed` and replaced it with `fromRegisteredAllocatorIdWithConsumed`, along with an additional `toAllocatorId` cast.

> [!NOTE]
> This is a partial fix for N-17. Some other points are more subjective, and the part regarding the `_revertWithInvalidBatchAllocationIfError` function has already been addressed.
