### PR TITLE
fix(N-16): fix `asBool` to return clean value and clean up unused helpers

### DIFF
--- a/src/lib/EfficiencyLib.sol
+++ b/src/lib/EfficiencyLib.sol
@@ -64,19 +64,7 @@ library EfficiencyLib {
      */
     function asBool(uint256 a) internal pure returns (bool b) {
         assembly ("memory-safe") {
-            b := a
-        }
-    }
-
-    /**
-     * @notice Internal pure function that converts a uint256 to a bytes12. Only
-     * safe when the input is known to have no dirty lower bits.
-     * @param a  The uint256 to convert.
-     * @return b The resulting bytes12 value.
-     */
-    function asBytes12(uint256 a) internal pure returns (bytes12 b) {
-        assembly ("memory-safe") {
-            b := a
+            b := iszero(iszero(a))
         }
     }
 
@@ -177,19 +165,6 @@ library EfficiencyLib {
      * @return b The resulting uint256.
      */
     function asUint256(ResetPeriod a) internal pure returns (uint256 b) {
-        assembly ("memory-safe") {
-            b := a
-        }
-    }
-
-    /**
-     * @notice Internal pure function that converts a uint256 to a ResetPeriod enum without
-     * performing any bounds checks. Do not use in cases where the reset period may be
-     * outside the acceptable bounds.
-     * @param a  The uint256 to convert.
-     * @return b The resulting ResetPeriod enum.
-     */
-    function asResetPeriod(uint256 a) internal pure returns (ResetPeriod b) {
         assembly ("memory-safe") {
             b := a
         }

--- a/src/lib/IdLib.sol
+++ b/src/lib/IdLib.sol
@@ -164,15 +164,20 @@ library IdLib {
     /**
      * @notice Internal pure function for building the "lock tag" from an
      * allocatorId, scope, and reset period.
-     * @param allocatorId The allocator ID.
+     * @param allocatorId The allocator ID, must be at most 92 bits: 4 bits for the compact flag, 88 bits from the allocator address.
      * @param scope       The scope of the resource lock (multichain or single chain).
      * @param resetPeriod The duration after which the resource lock can be reset.
-     * @return            The lock tag.
+     * @return lockTag    The lock tag.
      */
-    function toLockTag(uint96 allocatorId, Scope scope, ResetPeriod resetPeriod) internal pure returns (bytes12) {
+    function toLockTag(uint96 allocatorId, Scope scope, ResetPeriod resetPeriod)
+        internal
+        pure
+        returns (bytes12 lockTag)
+    {
         // Derive lock tag (pack scope, reset period, & allocator ID).
-        return ((scope.asUint256() << 255) | (resetPeriod.asUint256() << 252) | (allocatorId.asUint256() << 160))
-            .asBytes12();
+        assembly {
+            lockTag := or(or(shl(255, scope), shl(252, resetPeriod)), shl(160, allocatorId))
+        }
     }
 
     /**

--- a/test/lib/EfficiencyLib.t.sol
+++ b/test/lib/EfficiencyLib.t.sol
@@ -47,21 +47,6 @@ contract EfficiencyLibTest is Test {
         assertEq(val.asBool(), expected, "Fuzz test for asBool failed");
     }
 
-    function testAsBytes12() public pure {
-        uint256 val = type(uint240).max;
-        bytes12 expected = bytes12(bytes32(val));
-        assertEq(val.asBytes12(), expected, "Should convert uint256 to bytes12");
-
-        uint256 highVal = (uint256(1234567890) << 160) | val;
-        bytes12 truncated = bytes12(bytes32(highVal));
-        assertEq(highVal.asBytes12(), truncated, "Should truncate upper bits for bytes12");
-    }
-
-    function testFuzzAsBytes12(uint256 val) public pure {
-        bytes12 expected = bytes12(bytes32(val));
-        assertEq(val.asBytes12(), expected, "Fuzz test for asBytes12 failed");
-    }
-
     function testAsSanitizedAddress() public pure {
         uint256 val = uint256(uint160(address(0x123)));
         address expected = address(uint160(val));
@@ -108,16 +93,5 @@ contract EfficiencyLibTest is Test {
         assertEq(addrVal.asUint256(), uint256(uint160(addrVal)), "address -> uint256");
 
         assertEq(ResetPeriod.OneSecond.asUint256(), uint256(ResetPeriod.OneSecond), "ResetPeriod -> uint256");
-    }
-
-    function testAsResetPeriod() public pure {
-        uint256 periodVal = uint256(ResetPeriod.OneDay);
-        assertEq(uint8(periodVal.asResetPeriod()), uint8(ResetPeriod.OneDay), "uint256 -> ResetPeriod");
-    }
-
-    function testFuzzAsResetPeriod(uint8 periodVal) public pure {
-        vm.assume(periodVal < 8);
-        ResetPeriod actualEnum = periodVal.asResetPeriod();
-        assertEq(uint8(actualEnum), uint8(periodVal), "Fuzz test for asResetPeriod (uint8 value) failed");
     }
 }

--- a/test/unit/Emissary/EmissaryLogic.t.sol
+++ b/test/unit/Emissary/EmissaryLogic.t.sol
@@ -150,8 +150,9 @@ contract EmissaryLogicTest is Test {
 
     function toLockTag(uint96 _allocatorId, Scope _scope, ResetPeriod _resetPeriod) internal pure returns (bytes12) {
         // Derive lock tag (pack scope, reset period, & allocator ID).
-        return ((_scope.asUint256() << 255) | (_resetPeriod.asUint256() << 252) | (_allocatorId.asUint256() << 160))
-            .asBytes12();
+        return asBytes12(
+            ((_scope.asUint256() << 255) | (_resetPeriod.asUint256() << 252) | (_allocatorId.asUint256() << 160))
+        );
     }
 
     function fromLockTag(bytes12 tag)
@@ -168,5 +169,12 @@ contract EmissaryLogicTest is Test {
 
         // Extract allocatorId (bits 160 to 250, which is 91 bits)
         _allocatorId = uint96((value >> 160) & ((1 << 91) - 1));
+    }
+
+    // Note: expects value without dirty bits.
+    function asBytes12(uint256 val) private pure returns (bytes12 res) {
+        assembly {
+            res := val
+        }
     }
 }


### PR DESCRIPTION
- `asBool` – casts a `uint256` value to `bool` using `iszero`.  
- `asBytes12` – removed, as it was only used once in `toLockTag`.  
- `toLockTag` – rewritten to an equivalent version using assembly, replacing the previous `asBytes12` usage. No need to manually clear bits, since values are shifted left by the maximum they can store.  
- `asResetPeriod` – removed, as it was unused.