### PR TITLE
clean up tstorish a bit; coverage to 100%

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,3 +16,6 @@ dynamic_test_linking = true
 line_length = 120
 tab_width = 4
 bracket_spacing = true
+
+[lint]
+exclude_lints = ["mixed-case-function"]

--- a/snapshots/DepositAndRegisterForTest.json
+++ b/snapshots/DepositAndRegisterForTest.json
@@ -1,7 +1,7 @@
 {
-  "batchDepositRegisterFor": "79742",
-  "depositERC20AndRegisterForNoWitness": "78652",
+  "batchDepositRegisterFor": "79758",
+  "depositERC20AndRegisterForNoWitness": "78668",
   "depositNativeAndRegisterFor": "50799",
   "depositNativeAndRegisterForNoWitness": "50793",
-  "depositRegisterFor": "78658"
+  "depositRegisterFor": "78674"
 }


### PR DESCRIPTION
This PR removes unused code (namely the explicit `clearTstorish` function) and rearranges some functions and constants to put internal before private.

In doing so, code coverage has now reached 100%.