### PR TITLE
Use the same signature offset for batch and non-batch permit2 calls

### DIFF
--- a/src/lib/DepositViaPermit2Logic.sol
+++ b/src/lib/DepositViaPermit2Logic.sol
@@ -302,10 +302,7 @@ contract DepositViaPermit2Logic is DepositLogic {
                 assembly ("memory-safe") {
                     // Derive the total memory offset for the witness.
                     let totalWitnessMemoryOffset :=
-                        and(
-                            add(0x153, add(witness.length, iszero(iszero(witness.length)))),
-                            not(0x1f)
-                        )
+                        and(add(0x153, add(witness.length, iszero(iszero(witness.length)))), not(0x1f))
 
                     // Derive the signature offset value.
                     signatureOffsetValue :=

--- a/src/lib/DepositViaPermit2Logic.sol
+++ b/src/lib/DepositViaPermit2Logic.sol
@@ -303,7 +303,7 @@ contract DepositViaPermit2Logic is DepositLogic {
                     // Derive the total memory offset for the witness.
                     let totalWitnessMemoryOffset :=
                         and(
-                            add(add(0x147, add(witness.length, iszero(iszero(witness.length)))), mul(compactCategory, 0x0b)),
+                            add(0x153, add(witness.length, iszero(iszero(witness.length)))),
                             not(0x1f)
                         )
 


### PR DESCRIPTION
See: https://cantina.xyz/code/e5b26422-b8bf-4bc1-91b2-5056dc7730cf/findings/11

Note that since the review, the compact fragment size has increased, from 0x93 to 0xbd. So we instead now compute the upper bound for the offset as follows: 
- Batch typestring length: 0x48 (initial activation fragment) + 0xbd (compact fragment) + 0x2f (token permission fragment) = 0x134
- Add 0x1f as part of pattern to round up to the nearest word = 0×153

Note that the current implementation uses 0x147 + 0x0b = 0x152, which effectively only adds 0x1d to round up. This is incorrect as in case the resulting offset (before adding 0x1d) is 1 greater than a multiple of 0x20, we will not actually round up to the nearest word, e.g.: `and(add(0x21, 0x1d), not(0x1f)) = 0x20`